### PR TITLE
Bump excon

### DIFF
--- a/prx_access.gemspec
+++ b/prx_access.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hyperresource", "~> 0.9.4"
   spec.add_dependency "activesupport", ">= 4.0.0"
   spec.add_dependency "oauth2", "~> 1.4.1"
-  spec.add_dependency "excon", "~> 0.62.0"
+  spec.add_dependency "excon", "~> 0.88.0"
 
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"

--- a/prx_access.gemspec
+++ b/prx_access.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler", "~> 2.2.26"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
Bump to a more recent version of excon to facilitate downstream gem upgrades.